### PR TITLE
Filter out directories when globbing

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,3 +1,6 @@
+var fs = require('fs');
+var path = require('path');
+
 var glob = require('glob');
 var minimatch = require('minimatch');
 
@@ -42,7 +45,8 @@ exports.like = function like(obj, test) {
 
 
 /**
- * Generate an array of file names given an array of patterns.
+ * Generate an array of file names given an array of patterns.  Ignores
+ * directories.
  * @param {Array.<string>|string} patterns List of glob patterns or a single
  *     pattern.
  * @param {object} options Options to glob.
@@ -59,7 +63,19 @@ exports.globs = function(patterns, options, callback) {
   async.map(patterns, function(pattern, cb) {
     glob(pattern, options, cb);
   }, function(err, results) {
-    callback(err, err ? null : lo.unique(lo.flatten(results)));
+    if (err) {
+      return callback(err);
+    }
+    var cwd = options.cwd || process.cwd();
+    async.filter(lo.unique(lo.flatten(results)),
+        function(file, include) {
+          fs.stat(path.resolve(cwd, file), function(err, stats) {
+            include(!err && !stats.isDirectory());
+          });
+        },
+        function(filtered) {
+          callback(null, filtered);
+        });
   });
 };
 


### PR DESCRIPTION
The addition of the libtess.js directory in openlayers/ol3#1078 revealed an issue in closure-util.  The serve task was configuring a manager that [globs for src files](https://github.com/openlayers/ol3/blob/75fffd1f47a7ff87362dd3f523cabedb07a557ef/tasks/serve.js#L17) with `src/**/*.js`.  This results in the manager trying to read the `libtess.js` directory as a script.

A solution is to filter out files that are directories after globbing.
