### PR TITLE
Clearer error messages for known error codes

### DIFF
--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -264,6 +264,14 @@ exports.read = function(filename, callback) {
   filename = path.resolve(filename);
   fs.readFile(filename, function(err, source) {
     if (err) {
+      if (err.code === 'EISDIR') {
+        err = new Error('Trouble reading script.  ' +
+            'Expected a file name, got a directory name instead: ' +
+            filename);
+      } else if (err.code === 'ENOENT') {
+        err = new Error('Trouble reading script.  ' +
+            'File not found: ' + filename);
+      }
       return callback(err);
     }
     var script;


### PR DESCRIPTION
This fixes messages like:

```
ERR! ol EISDIR
```

Providing the user with messages like this instead:

```
ERR! ol Trouble reading script.  Expected a file name, got a directory name instead: /Users/tschaub/projects/ol3/src/ol
```

I'll fix the underlying problem separately.
