### PR TITLE
Ignore directory changes

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -281,7 +281,12 @@ Manager.prototype._startWatch = function() {
   var paths = this._lib.concat(this._main);
   var gaze = new Gaze(paths);
   gaze.on('changed', this._handleChanged.bind(this));
-  gaze.on('added', this._handleChanged.bind(this));
+  gaze.on('added', function(filepath) {
+    // TODO: remove this when gaze@0.5 is published
+    if (minimatches(path.relative(this._cwd, filepath), paths)) {
+      this._handleChanged(filepath);
+    }
+  }.bind(this));
   gaze.on('deleted', this._handleDeleted.bind(this));
 };
 


### PR DESCRIPTION
After a `git checkout` it was common to see things like this from the server:

```
ERR! ol Trouble reading script.  Expected a file name, got a directory name instead: /path/to/ol3/src/ol
```

This was caused by gaze emitting `add` events for directories even if they didn't match the watch patterns.  This should be resolved when `v0.5` is published.  This workaround solves the problem until then (and may be a long term fix for Node 0.8 support).
