### PR TITLE
Accept JVM arguments

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -13,15 +13,19 @@ var util = require('./util');
  *     the '--' prefix).  For flags (options without a value), provide a
  *     boolean.  For options that appear multiple times, provide an array of
  *     values.
+ * @param {Array} jvm Java VM arguments.  Any additional arguments for the JVM.
+ *     Default is `['-server', '-XX:+TieredCompilation']`.  Note that `-jar`
+ *     and the path to the compiler.jar will always be appended.
  * @param {function(Error, string)} callback Callback called with any
  *     compilation error or the result.
  */
-exports = module.exports = function(options, callback) {
+exports = module.exports = function(options, jvm, callback) {
+  if (arguments.length === 2) {
+    callback = jvm;
+    jvm = ['-server', '-XX:+TieredCompilation'];
+  }
   var compilerDir = util.getDependency('compiler', config.get('compiler_url'));
-  var args = [
-    '-server', '-XX:+TieredCompilation', '-jar',
-    path.join(compilerDir, 'compiler.jar')
-  ];
+  var args = jvm.concat('-jar', path.join(compilerDir, 'compiler.jar'));
 
   // add all options
   if (options) {


### PR DESCRIPTION
By default, use `['-server', '-XX:+TieredCompilation']` but [accept alternatives](https://code.google.com/p/closure-compiler/wiki/FAQ#What_are_the_recommended_Java_VM_command-line_options?).
