### PR TITLE
Allow cwd to be configured for compile

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -9,28 +9,23 @@ var util = require('./util');
 
 /**
  * Compile scripts.
- * @param {Object} options Compiler options (same as compiler.jar options minus
- *     the '--' prefix).  For flags (options without a value), provide a
- *     boolean.  For options that appear multiple times, provide an array of
- *     values.
- * @param {Array} jvm Java VM arguments.  Any additional arguments for the JVM.
- *     Default is `['-server', '-XX:+TieredCompilation']`.  Note that `-jar`
- *     and the path to the compiler.jar will always be appended.
+ * @param {Object} options An object with optional `compile`, `cwd`, and `jvm`
+ *     properties.
  * @param {function(Error, string)} callback Callback called with any
  *     compilation error or the result.
  */
-exports = module.exports = function(options, jvm, callback) {
-  if (arguments.length === 2) {
-    callback = jvm;
-    jvm = ['-server', '-XX:+TieredCompilation'];
+exports = module.exports = function(options, callback) {
+  options = options || {};
+  if (!options.jvm) {
+    options.jvm = ['-server', '-XX:+TieredCompilation'];
   }
   var compilerDir = util.getDependency('compiler', config.get('compiler_url'));
-  var args = jvm.concat('-jar', path.join(compilerDir, 'compiler.jar'));
+  var args = options.jvm.concat('-jar', path.join(compilerDir, 'compiler.jar'));
 
-  // add all options
-  if (options) {
-    Object.keys(options).forEach(function(key) {
-      var value = options[key];
+  // add all compile options
+  if (options.compile) {
+    Object.keys(options.compile).forEach(function(key) {
+      var value = options.compile[key];
       if (typeof value === 'boolean') {
         if (value) {
           args.push('--' + key);
@@ -45,7 +40,7 @@ exports = module.exports = function(options, jvm, callback) {
   }
 
   log.silly('compile', 'java ' + args.join(' '));
-  var child = cp.spawn('java', args);
+  var child = cp.spawn('java', args, {cwd: options.cwd || process.cwd()});
 
   var out = [];
   child.stdout.on('data', function(chunk) {

--- a/readme.md
+++ b/readme.md
@@ -61,12 +61,13 @@ The `getDependencies` function generates a list of script paths in dependency or
  * **config** - `Object` A configuration object of the same form as the [manager config](#manager-config).
  * **callback** - `function(Error, Array.<string>)` Called with a list of script paths in dependency order (or a parsing error).
 
-### <a id="compile">`compile(options, [jvm], callback)`</a>
+### <a id="compile">`compile(options, callback)`</a>
 
 The `compile` function drives the Closure Compiler.
 
- * **options** - `Object` [Options](compiler-options.txt) for the compiler (without the `--` prefix).  E.g. the `--output_wrapper` option could be specified with `{output_wrapper: '(function(){%output%})();'}`.  For options that can be specified multiple times, provide an array of values (e.g. `{js: ['one.js', 'two.js']}`).  For options that are flags (no value), provide a boolean (e.g. `{use_types_for_optimization: true}`).
- * **jvm** - `Array.<string>` Optional arguments for the JVM.  If this argument is absent (if the function is called with two arguments), `['-server', '-XX:+TieredCompilation']` will be used as JVM arguments.  To use [different arguments](https://github.com/google/closure-compiler/wiki/FAQ#what-are-the-recommended-java-vm-command-line-options), provide an array.
+ * **options.compile** - `Object` [Options](compiler-options.txt) for the compiler (without the `--` prefix).  E.g. the `--output_wrapper` option could be specified with `{output_wrapper: '(function(){%output%})();'}`.  For options that can be specified multiple times, provide an array of values (e.g. `{js: ['one.js', 'two.js']}`).  For options that are flags (no value), provide a boolean (e.g. `{use_types_for_optimization: true}`).
+ * **options.cwd** - `string` Optional path to set as the current working directory.  Default is `process.cwd()`.  All relative paths in the compiler options must be relative to `cwd`.
+ * **options.jvm** - `Array.<string>` Optional arguments for the JVM.  If this argument is absent (if the function is called with two arguments), `['-server', '-XX:+TieredCompilation']` will be used as JVM arguments.  To use [different arguments](https://github.com/google/closure-compiler/wiki/FAQ#what-are-the-recommended-java-vm-command-line-options), provide an array.
  * **callback** - `function(Error, string)` Called with the compiler output (or any compilation error).
 
 ## Configuration


### PR DESCRIPTION
This makes it possible to specify the cwd for compilation.  The Compiler resolves all paths in compile options relative to the current working directory.  By default, `process.cwd()` is used.  To override this, a `cwd` option can be provided.
