### PR TITLE
Update Closure library url in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ The `closure-util` package downloads the Closure Compiler and Closure Library wh
 Available configuration options (see `default-config.json` for default values):
 
  * `compiler_url` - URL for the compiler zip archive (e.g. `http://dl.google.com/closure-compiler/compiler-latest.zip`).
- * `library_url` - URL for the Closure Library zip archive (an archive for revision of the library can be downloaded by looking for the "Download zip" link in the [source browser](https://code.google.com/p/closure-library/source/browse/)).
+ * `library_url` - URL for the Closure Library zip archive (e.g. `https://github.com/google/closure-library/archive/master.zip`).
  * `log_level` - Logging level.  Allowed values are `silly`, `verbose`, `info`, `warn`, and `error` (default is `info`).
 
 Environment variables are given precedence over `closure-util.json` values.  For example, the following would set the logging level for the install regardless of the default or anything found in `closure-util.json`:


### PR DESCRIPTION
Source/archive on code.google.com is no longer maintained
