### PR TITLE
Updating send and grunt-contrib-watch dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "acorn": "0.4.2",
     "async": "0.2.9",
     "gaze": "0.4.3",
-    "get-down": "0.4.0",
+    "get-down": "0.5.0",
     "glob": "3.2.7",
     "graceful-fs": "3.0.2",
     "handlebars": "1.3.0",


### PR DESCRIPTION
- `npm test` still passes all 37 tests.
- `nsp audit-shrinkwrap` still gives the following warnings:
  
  ``` sh
  $ nsp audit-shrinkwrap
  Name  Installed  Patched  Vulnerable Dependency
  qs      0.6.6     >= 1.x  closure-util > get-down > request
  qs      0.5.6     >= 1.x  closure-util > grunt-contrib-watch > tiny-lr-fork
  ```

Fixes #36
