### PR TITLE
send.root is now deprecated

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -171,9 +171,11 @@ Server.prototype._requestListener = function(req, res) {
       }
     }
   } else {
+    var options = {
+      root: this._root
+    };
     // assume static
-    send(req, pathname)
-        .root(this._root)
+    send(req, pathname, options)
         .on('error', this._handleStaticError.bind(this, req, res))
         .pipe(res);
   }


### PR DESCRIPTION
Since upgrading to closure-util 1.0.0 I get the following warning:

``` bash
send deprecated send.root: pass root as option node_modules/closure-util/lib/server.js:176:10
```

This PR fixes this issue by sending an options object.
