### PR TITLE
Replace slashes w/ backslashes on Windows

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -96,6 +96,12 @@ var Manager = exports.Manager = function Manager(options) {
    */
   this._closed = false;
 
+  /**
+   * The script is run on Windows.
+   * @type {boolean}
+   */
+  this._isWindows = process.platform.indexOf('win') === 0;
+
   var paths = lib.concat(main);
   if (options.closure !== false) {
     var closure = getLibraryPath();
@@ -241,6 +247,10 @@ Manager.prototype.getErrors = function() {
  * @return {Script} The script (or null if not found).
  */
 Manager.prototype.getScript = function(name) {
+  if (this._isWindows) {
+    // replace slashes with backslashes
+    name = name.replace(/\//g, '\\');
+  }
   return this._scripts[name] || null;
 };
 


### PR DESCRIPTION
Let me start by saying I do not like this PR at all - but I happened to require Windows for a moment - and I ran into the same problem as described here:
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!searchin/ol3-dev/closure-util/ol3-dev/J1ziaxU47W4/3X54KSsLLOsJ.

The issue:
On Windows, the keys used in the scripts cache (`this._scripts`) contain backslashes, whereas the client requests scripts by their web server location, i.e. with forward slashes. Because of this, the server is unable to find the files and returns 404 errors instead.

This PR fixed it for me.
