### PR TITLE
Upgrade Closure Library

### DIFF
--- a/default-config.json
+++ b/default-config.json
@@ -1,5 +1,5 @@
 {
   "compiler_url": "http://dl.google.com/closure-compiler/compiler-20150126.zip",
-  "library_url": "https://github.com/google/closure-library/archive/97e8a0c0fc7238a56cc4dacd4a96fd4c0735b992.zip",
+  "library_url": "https://github.com/google/closure-library/archive/0011afd534469ba111786fe68300a634e08a4d80.zip",
   "log_level": "info"
 }


### PR DESCRIPTION
This commit uses a version of Closure Library that is compatible with Closure Compiler v20150126, which is the version of Closure Compiler we use at the moment. The same version as ol3 is used (0011afd534469ba111786fe68300a634e08a4d80).