### PR TITLE
Add a "build" command to the "closure-util" bin

### DIFF
--- a/bin/closure-util.js
+++ b/bin/closure-util.js
@@ -3,6 +3,7 @@ var log = require('npmlog');
 var parser = require('nomnom');
 
 var deps = require('../lib/deps');
+var build = require('../lib/build');
 
 parser.options({
   loglevel: {
@@ -57,6 +58,29 @@ parser.command('update').callback(function() {
     }
   });
 }).help('Update both the Library and the Compiler');
+
+parser.command('build')
+  .option('config', {
+    position: 1,
+    required: true,
+    help: 'Path to JSON config file'
+  })
+  .option('output', {
+    position: 2,
+    required: true,
+    help: 'Output file path'
+  })
+  .callback(function(opts) {
+    var configFile = opts.config;
+    var outputFile = opts.output;
+    build(configFile, outputFile, function(err) {
+      if (err) {
+        log.error('closure-util', err.message);
+        process.exit(1);
+      }
+      process.exit(0);
+    });
+  }).help('Build with Closure Compiler');
 
 var options = parser.parse();
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,0 +1,104 @@
+var async = require('async');
+var fse = require('fs-extra');
+var log = require('npmlog');
+
+var buildconfig = require('./buildconfig');
+var closure = require('./index');
+var config = require('./config');
+
+
+/**
+ * Configurable log level.
+ * @type {string}
+ */
+log.level = config.get('log_level');
+
+
+/**
+ * Read the build configuration file.
+ * @param {string} configFile Config file.
+ * @param {function(Error, Object)} callback Called with the build
+ *    configuration object or any error.
+ */
+function _readConfig(configFile, callback) {
+  log.info('closure-util', 'Reading build config');
+  buildconfig.readConfig(configFile, callback);
+}
+
+
+/**
+ * Get the list of sources sorted in dependency order.
+ * @param {Object} config Build configuration object.
+ * @param {function(Error, Array.<string>)} callback Called with a
+ *     list of paths or any error.
+ */
+function _getDependencies(config, callback) {
+  log.info('closure-util', 'Getting Closure dependencies');
+  var options = {
+    lib: config.lib || config.src,
+    cwd: config.cwd || process.cwd()
+  };
+  closure.getDependencies(options, function(err, paths) {
+    if (err) {
+      callback(err);
+      return;
+    }
+    callback(null, config, paths);
+  });
+}
+
+
+/**
+ * Run the compiler.
+ * @param {Object} config Build configuration object.
+ * @param {Array.<string>} paths List of paths to source files.
+ * @param {function(Error, string)} callback Called with the compiled output
+ *     or any error.
+ */
+function _compile(config, paths, callback) {
+  log.info('closure-util', 'Compiling ' + paths.length + ' sources');
+  var options = {
+    compile: config.compile,
+    cwd: config.cwd || process.cwd(),
+    jvm: config.jvm
+  };
+  options.compile.js = paths.concat(config.compile.js || []);
+  closure.compile(options, callback);
+}
+
+
+/**
+ * Write the compiled code to the output file.
+ * @param {string} outputFile The output file.
+ * @param {string} code The code to write to the output file.
+ * @param {function(Error)} callback Called with the error if any.
+ */
+function _writeOutput(outputFile, code, callback) {
+  log.info('closure-util', 'Writing compiled code to ' + outputFile);
+  fse.outputFile(outputFile, code, callback);
+}
+
+
+/**
+ * This module's main function. This function reads the build config
+ * file, compliles the JavaScript code, and writes the compiled code
+ * to the output file.
+ * @param {string} configFile Config file path.
+ * @param {string} ouputFile Output file path.
+ * @param {function(Error)} callback Called when the compilation is
+ *     finished or when any error occured.
+ */
+module.exports = function(configFile, outputFile, callback) {
+  async.waterfall([
+    _readConfig.bind(null, configFile),
+    _getDependencies,
+    _compile,
+    _writeOutput.bind(null, outputFile)
+  ], function(err) {
+    if (err) {
+      callback(err);
+    } else {
+      callback(null);
+    }
+  });
+};

--- a/lib/buildconfig.js
+++ b/lib/buildconfig.js
@@ -1,0 +1,63 @@
+var fs = require('graceful-fs');
+var log = require('npmlog');
+
+var config = require('./config');
+
+
+/**
+ * Configurable log level.
+ */
+log.level = config.get('log_level');
+
+
+/**
+ * Assert that a provided config object is valid.
+ * @param {Object} config Build configuration object.
+ */
+function assertValidConfig(config) {
+  if (!config.lib) {
+    config.lib = config.src;
+  }
+  if (!Array.isArray(config.lib)) {
+    throw new Error('Config "lib" must be an array');
+  }
+  if (typeof config.compile !== 'object') {
+    throw new Error('Config "compile" must be an object');
+  }
+  if (config.jvm && !Array.isArray(config.jvm)) {
+    throw new Error('Config "jvm" must be an array');
+  }
+}
+
+
+/**
+ * Read the build configuration file.
+ * @param {string} configPath Path to config file.
+ * @param {function(Error, Object)} callback Callback.
+ */
+exports.readConfig = function(configPath, callback) {
+  fs.readFile(configPath, function(err, data) {
+    if (err) {
+      if (err.code === 'ENOENT') {
+        err = new Error('Unable to find config file: ' + configPath);
+      }
+      callback(err);
+      return;
+    }
+    var config;
+    try {
+      config = JSON.parse(String(data));
+    } catch (err2) {
+      callback(new Error('Trouble parsing config as JSON: ' +
+          err2.message));
+      return;
+    }
+    try {
+      assertValidConfig(config);
+    } catch (err3) {
+      callback(err3);
+      return;
+    }
+    callback(null, config);
+  });
+};

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "grunt-contrib-jshint": "~0.8.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-mocha-test": "~0.8.1",
-    "supertest": "^0.15.0"
+    "supertest": "^0.15.0",
+    "temp": "^0.8.1"
   },
   "scripts": {
     "postinstall": "node ./bin/closure-util.js update",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "acorn": "0.4.2",
     "async": "0.2.9",
+    "fs-extra": "^0.17.0",
     "gaze": "0.4.3",
     "get-down": "0.5.0",
     "glob": "3.2.7",
@@ -32,11 +33,11 @@
     "lodash": "2.4.1",
     "minimatch": "0.2.14",
     "mkdirp": "0.5.0",
+    "nomnom": "~1.8.0",
     "npmlog": "0.0.6",
     "rimraf": "2.2.8",
     "send": "0.12.2",
-    "socket.io": "0.9.16",
-    "nomnom": "~1.8.0"
+    "socket.io": "0.9.16"
   },
   "devDependencies": {
     "chai": "~1.8.1",

--- a/readme.md
+++ b/readme.md
@@ -81,12 +81,21 @@ Available configuration options (see `default-config.json` for default values):
 
 ## CLI
 
-The `closure-util` command line utility allows you to update (or install) specific versions of the Closure Compiler or Closure Library for use with your project.  See the [configuration](#configuration) section above for information on how to configure URLs for specific versions of the Compiler or Library.  The `closure-util` utility will look for this configuration when executing one of the commands below.
+The `closure-util` command line utility provides commands for updating (or installing) specific versions of the Closure Compiler and Closure Library for use with your project, and a command for building your project using the Closure Compiler.
 
  * `closure-util update` - Update both the Compiler and Library.
  * `closure-util update-compiler` - Update the Compiler.
  * `closure-util update-library` - Update the Library.
+ * `closure-util build` - Build a JavaScript application.
  * `closure-util --help` - Display command usage and options.
+
+See the [configuration](#configuration) section above for information on how to configure URLs for specific versions of the Compiler or Library.  The `closure-util` utility will look for this configuration when executing one of the `update`, `update-compiler` or `update-library` commands.
+
+This is how the `build` command is used:
+
+    closure-util build build.json app.min.js
+
+where `build.json` is a build config file and `app.min.js` in the output file including the compiled code. As an example for a build config file see the [`build-config.json`](test/fixtures/build-config.json) file used in the `closure-util` tests.
 
 ## Development
 

--- a/test/fixtures/basic/one.js
+++ b/test/fixtures/basic/one.js
@@ -23,7 +23,7 @@ basic.one.Class = function(things) {
 
 /**
  * Do something for each thing.
- * @param {function} fn Function to be called with each thing.
+ * @param {function()} fn Function to be called with each thing.
  */
 basic.one.Class.prototype.forEach = function(fn) {
   goog.array.forEach(this.things_, fn);

--- a/test/fixtures/build-config.json
+++ b/test/fixtures/build-config.json
@@ -1,0 +1,63 @@
+{
+  "lib": [
+    "test/fixtures/basic/**.js"
+  ],
+  "compile": {
+    "closure_entry_point": "basic.one",
+    "externs": [
+    ],
+    "define": [
+      "goog.array.ASSUME_NATIVE_FUNCTIONS=true",
+      "goog.dom.ASSUME_STANDARDS_MODE=true",
+      "goog.json.USE_NATIVE_JSON=true",
+      "goog.DEBUG=false"
+    ],
+    "js": [
+    ],
+    "jscomp_error": [
+      "accessControls",
+      "ambiguousFunctionDecl",
+      "checkEventfulObjectDisposal",
+      "checkRegExp",
+      "checkStructDictInheritance",
+      "checkTypes",
+      "checkVars",
+      "const",
+      "constantProperty",
+      "deprecated",
+      "duplicateMessage",
+      "es3",
+      "es5Strict",
+      "externsValidation",
+      "fileoverviewTags",
+      "globalThis",
+      "internetExplorerChecks",
+      "invalidCasts",
+      "misplacedTypeAnnotation",
+      "missingGetCssName",
+      "missingProperties",
+      "missingProvide",
+      "missingRequire",
+      "missingReturn",
+      "newCheckTypes",
+      "nonStandardJsDocs",
+      "suspiciousCode",
+      "strictModuleDepCheck",
+      "typeInvalidation",
+      "undefinedNames",
+      "undefinedVars",
+      "uselessCode",
+      "visibility"
+    ],
+    "jscomp_off": [
+      "unknownDefines"
+    ],
+    "extra_annotation_name": [
+      "api", "observable"
+    ],
+    "compilation_level": "ADVANCED",
+    "warning_level": "VERBOSE",
+    "output_wrapper": "(function(){%output%})();",
+    "use_types_for_optimization": true
+  }
+}

--- a/test/spec/build.spec.js
+++ b/test/spec/build.spec.js
@@ -1,0 +1,27 @@
+var fs = require('fs');
+var path = require('path');
+var temp = require('temp').track();
+
+var build = require('../../lib/build');
+
+var helper = require('../helper');
+
+var assert = helper.assert;
+var fixtures = path.join(__dirname, '..', 'fixtures');
+
+
+describe('build', function() {
+  it('creates an output file', function(done) {
+    // this test runs the compiler, increase the timeout value
+    this.timeout(30000);
+    var outputFile = temp.path({suffix: '.js'});
+    var configFile = path.join(fixtures, 'build-config.json');
+    build(configFile, outputFile, function(err) {
+      assert.isNull(err);
+      fs.exists(outputFile, function(exists) {
+        assert.isTrue(exists);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This commit adds a command named "build" to the "closure-util" binary. This is how the command is used:

```
./node_modules/.bin/closure-util build build.json app.min.js
```

where "build.json" is the build configuration file and "app.min.js" is the output file.