### PR TITLE
Update for building on Windows

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -120,7 +120,7 @@ exports.getDependency = getDependency;
  * @return {string} Path.
  */
 exports.getLibraryPath = function() {
-  return getDependency('library', config.get('library_url'));
+  return getDependency('library', config.get('library_url')).replace(/\\/g,"/");
 };
 
 
@@ -129,5 +129,5 @@ exports.getLibraryPath = function() {
  * @return {string} Path.
  */
 exports.getCompilerPath = function() {
-  return getDependency('compiler', config.get('compiler_url'));
+  return getDependency('compiler', config.get('compiler_url')).replace(/\\/g,"/");
 };


### PR DESCRIPTION
Ensure POSIX paths are returned from getCompilerPath and getLibraryPath. On Windows, back slashes are converted to forward slashes.