### PR TITLE
Allow to compile static libraries

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -71,6 +71,9 @@ function getDependencies(config, callback) {
       callback(err);
       return;
     }
+    if (config.static && config.static.length) {
+      paths = config.static.concat(paths);
+    }
     callback(null, config, paths);
   });
 }

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -5,6 +5,9 @@ var log = require('npmlog');
 
 var util = require('./util');
 
+var fs = require('fs');
+var flagfileName;
+
 
 /**
  * Compile scripts.
@@ -23,22 +26,25 @@ exports = module.exports = function(options, callback) {
 
   // add all compile options
   if (options.compile) {
+	var flagfileOptions = [];
     Object.keys(options.compile).forEach(function(key) {
       var value = options.compile[key];
       if (typeof value === 'boolean') {
         if (value) {
-          args.push('--' + key);
+          flagfileOptions.push('--' + key);
         }
       } else {
         var values = Array.isArray(value) ? value : [value];
         for (var i = 0, ii = values.length; i < ii; ++i) {
-          args.push('--' + key, values[i]);
+          flagfileOptions.push('--' + key, values[i]);
         }
       }
     });
+	flagfileName = path.join(compilerDir, "flagfile_" + Date.now());
+	fs.writeFileSync(flagfileName, flagfileOptions.join(" "));
+	args.push('--flagfile=' + flagfileName);
   }
 
-  log.silly('compile', 'java ' + args.join(' '));
   var child = cp.spawn('java', args, {cwd: options.cwd || process.cwd()});
 
   var out = [];
@@ -56,6 +62,9 @@ exports = module.exports = function(options, callback) {
       err = new Error('Process exited with non-zero status, ' +
           'see log for more detail: ' + code);
     }
+	if (flagfileName) {
+		fs.unlinkSync(flagfileName);
+	}
     callback(err, out.join(''));
   });
 };

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -5,9 +5,6 @@ var log = require('npmlog');
 
 var util = require('./util');
 
-var fs = require('fs');
-var flagfileName;
-
 
 /**
  * Compile scripts.
@@ -26,25 +23,22 @@ exports = module.exports = function(options, callback) {
 
   // add all compile options
   if (options.compile) {
-    var flagfileOptions = [];
     Object.keys(options.compile).forEach(function(key) {
       var value = options.compile[key];
       if (typeof value === 'boolean') {
         if (value) {
-          flagfileOptions.push('--' + key);
+          args.push('--' + key);
         }
       } else {
         var values = Array.isArray(value) ? value : [value];
         for (var i = 0, ii = values.length; i < ii; ++i) {
-          flagfileOptions.push('--' + key, values[i]);
+          args.push('--' + key, values[i]);
         }
       }
     });
-    flagfileName = path.join(compilerDir, 'flagfile_' + Date.now());
-    fs.writeFileSync(flagfileName, flagfileOptions.join(' '));
-    args.push('--flagfile=' + flagfileName);
   }
 
+  log.silly('compile', 'java ' + args.join(' '));
   var child = cp.spawn('java', args, {cwd: options.cwd || process.cwd()});
 
   var out = [];
@@ -61,9 +55,6 @@ exports = module.exports = function(options, callback) {
     if (code !== 0) {
       err = new Error('Process exited with non-zero status, ' +
           'see log for more detail: ' + code);
-    }
-    if (flagfileName) {
-      fs.unlinkSync(flagfileName);
     }
     callback(err, out.join(''));
   });

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -26,7 +26,7 @@ exports = module.exports = function(options, callback) {
 
   // add all compile options
   if (options.compile) {
-	var flagfileOptions = [];
+    var flagfileOptions = [];
     Object.keys(options.compile).forEach(function(key) {
       var value = options.compile[key];
       if (typeof value === 'boolean') {
@@ -40,9 +40,9 @@ exports = module.exports = function(options, callback) {
         }
       }
     });
-	flagfileName = path.join(compilerDir, "flagfile_" + Date.now());
-	fs.writeFileSync(flagfileName, flagfileOptions.join(" "));
-	args.push('--flagfile=' + flagfileName);
+    flagfileName = path.join(compilerDir, 'flagfile_' + Date.now());
+    fs.writeFileSync(flagfileName, flagfileOptions.join(' '));
+    args.push('--flagfile=' + flagfileName);
   }
 
   var child = cp.spawn('java', args, {cwd: options.cwd || process.cwd()});
@@ -62,9 +62,9 @@ exports = module.exports = function(options, callback) {
       err = new Error('Process exited with non-zero status, ' +
           'see log for more detail: ' + code);
     }
-	if (flagfileName) {
-		fs.unlinkSync(flagfileName);
-	}
+    if (flagfileName) {
+      fs.unlinkSync(flagfileName);
+    }
     callback(err, out.join(''));
   });
 };


### PR DESCRIPTION
It's impossible right now to compile static libraries (e.g jquery, underscrore, etc) using closure-util, it just cuts them out and compiles only closure dependencies. This change allows to add all static libraries to `config.static: []` and they all will be prepended to bundle file.