### PR TITLE
Move command line arguments to flagfile

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -5,6 +5,9 @@ var log = require('npmlog');
 
 var util = require('./util');
 
+var fs = require('fs');
+var flagfileName;
+
 
 /**
  * Compile scripts.
@@ -23,22 +26,25 @@ exports = module.exports = function(options, callback) {
 
   // add all compile options
   if (options.compile) {
+    var flagfileOptions = [];
     Object.keys(options.compile).forEach(function(key) {
       var value = options.compile[key];
       if (typeof value === 'boolean') {
         if (value) {
-          args.push('--' + key);
+          flagfileOptions.push('--' + key);
         }
       } else {
         var values = Array.isArray(value) ? value : [value];
         for (var i = 0, ii = values.length; i < ii; ++i) {
-          args.push('--' + key, values[i]);
+          flagfileOptions.push('--' + key, values[i]);
         }
       }
     });
+    flagfileName = path.join(compilerDir, 'flagfile_' + Date.now());
+    fs.writeFileSync(flagfileName, flagfileOptions.join(' '));
+    args.push('--flagfile=' + flagfileName);
   }
 
-  log.silly('compile', 'java ' + args.join(' '));
   var child = cp.spawn('java', args, {cwd: options.cwd || process.cwd()});
 
   var out = [];
@@ -55,6 +61,9 @@ exports = module.exports = function(options, callback) {
     if (code !== 0) {
       err = new Error('Process exited with non-zero status, ' +
           'see log for more detail: ' + code);
+    }
+    if (flagfileName) {
+      fs.unlinkSync(flagfileName);
     }
     callback(err, out.join(''));
   });


### PR DESCRIPTION
This change fixes builds under MS Windows environment.

The issue. When I tried to build OpenLayers application with closure compiler following this guide, it always failed throwing error ENAMETOOLONG. After investigation it became clear that filesystem limitation allows only 32k chars per command to execute. So the obvious solution is to move command line flags to --flagfile. 
After applying this fix application build works fine.