### PR TITLE
enable goog.modules for use es6

### DIFF
--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -312,8 +312,8 @@ Script.prototype._getProvides = function() {
   var provides = this._ast.body.reduce(function(provides, statement) {
     if (like(statement, provideNode)) {
       provides.push(statement.expression.arguments[0].value);
-    }else if (like(statement, moduleNode)) {
-       provides.push(statement.expression.arguments[0].value);
+    } else if (like(statement, moduleNode)) {
+      provides.push(statement.expression.arguments[0].value);
     } else if (like(statement, googNode)) {
       base = true;
     }


### PR DESCRIPTION
Add the possibility to use a goog.module to build the dependencies to make the compilation