### PR TITLE
Properly handle null in like util function

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -33,7 +33,7 @@ exports.like = function like(obj, test) {
   } else {
     // null, undefined, string, number, boolean
     is = Object.is(obj, test);
-    if (!is && typeof test === 'object' && typeof obj === 'object') {
+    if (!is && typeof test === 'object' && typeof obj === 'object' && obj !== null) {
       // other object (excluding Date, RegExp, Number, String, Boolean)
       var testKeys = Object.keys(test).sort();
       if (like(Object.keys(obj).sort(), testKeys)) {

--- a/test/spec/util.spec.js
+++ b/test/spec/util.spec.js
@@ -129,6 +129,15 @@ describe('like', function() {
     assert.isTrue(like(true, '*'));
   });
 
+  it('compares null literals', function() {
+    assert.isTrue(like(null, null));
+    assert.isFalse(like(null, undefined));
+    assert.isFalse(like(null, 42));
+    assert.isFalse(like(null, ''));
+    assert.isFalse(like(null, 'something'));
+    assert.isFalse(like(null, [42]));
+    assert.isFalse(like(null, {foo: 'bar'}));
+  });
 });
 
 var fixtures = path.join(__dirname, '..', 'fixtures');


### PR DESCRIPTION
Comparaison to null was not working in the case of an object:
"TypeError: Cannot convert undefined or null to object".