### PR TITLE
Add Manager closure option to Readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ Main options:
 More advanced options:
 
  * **config.ignoreRequires** - `string|undefined` A regular expression string. The manager will ignore matching `goog.require`'s that cannot be satisfied instead of throwing an exception. Optional.
+ * **config.closure** - `boolean|undefined` Whether to include Closure library. Default `true`.
 
 The manager is an [event emitter](http://nodejs.org/api/events.html#events_class_events_eventemitter) that emits the following events:
 


### PR DESCRIPTION
This option is in the code, but doesn't seem to be documented anywhere. Docs only change.