### PR TITLE
Download compiler and library using HTTPS

### DIFF
--- a/default-config.json
+++ b/default-config.json
@@ -1,5 +1,5 @@
 {
-  "compiler_url": "http://dl.google.com/closure-compiler/compiler-20171112.zip",
-  "library_url": "http://github.com/google/closure-library/archive/v20171112.zip",
+  "compiler_url": "https://dl.google.com/closure-compiler/compiler-20171112.zip",
+  "library_url": "https://github.com/google/closure-library/archive/v20171112.zip",
   "log_level": "info"
 }


### PR DESCRIPTION
This reverts commit fb3f4b07b56231ea6ab1e3eb718fddcadb265fc4.

That commit changed the download of the compiler and library to be done over plain, unencrypted HTTP.

This caused a [Node Security Advisory](https://nodesecurity.io/advisories/165), which states:

> Affected versions of closure-util insecurely download an executable over an unencrypted HTTP connection.
>
> In scenarios where an attacker has a privileged network position, it is possible to intercept the response and replace the executable with a malicious one, resulting in code execution on the system running closure-util.

The original change from HTTPS to HTTP was done due to some users reporting that their corporate networks were blocking or failing to download over HTTPS. While this is unfortunate, trading the security of every user of openlayers for a few users with poorly configured networks is not a good balance. This reverts the commit, to ensure that it is not possible for an attacker to compromise the
machine downloading OpenLayers for the majority of users.

For those few who need it, it is still possible to fork this repository and apply the patch to use HTTP, as ill-advised as that would be. It is also possible for them to pin to the version of OpenLayers that contains the above vulnerability.